### PR TITLE
Fixed memory leak caused by route change and "hanging" DOM elements

### DIFF
--- a/ngReact.js
+++ b/ngReact.js
@@ -317,6 +317,10 @@ angular.module('ngReact', [])
         } else {
           renderComponent();
         }
+
+        scope.$on('$destroy', function () {
+          React.unmountComponentAtNode(elem[0]);
+        });
       }
     }
   }]);


### PR DESCRIPTION
This commit fixes a memory leak caused by unloading Angular templates. Basically what happens is if you remove the Angular template, React components it contained would not get unmounted and would cause React components to leave DOM elements hanging around. This caused the browser to consume more and more memory until it became completely unresponsive. The effect can be experienced on huge lists with very high number of DOM elements (tracked it down using Chrome dev tools profiling).

I simply added React.unmountComponentAtNode() on directive scope $destroy which fixed the issue.

The patch is applied only to the unminified version of ngReact and new ngReact.min should be generated after pull.
