### PR TITLE
Switching dependencies to peerDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
+  - "4"
   - "0.12"
-  - "0.11"
   - "0.10"
-  - iojs
+  - node
 before_install: npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
     "url": "https://github.com/davidchang/ngReact.git"
   },
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "angular": "<2.0.0",
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": ">=0.14.2",
+    "react-dom": ">=0.14.2"
   },
   "browserify-shim": {
     "angular": "global:angular"
   },
   "devDependencies": {
+    "angular": "^1.4.7",
     "angular-mocks": "^1.3.6",
     "browserify": "^7.0.3",
     "browserify-shim": "^3.8.1",
@@ -33,12 +34,15 @@
     "grunt-docco": "0.3.3",
     "grunt-karma": "0.12.0",
     "jasmine-core": "2.3.4",
+    "karma": "^0.13.14",
     "karma-browserify": "1.0.1",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "0.2.0",
     "load-grunt-tasks": "0.1.0",
     "phantomjs": "1.9.17",
-    "react-addons-test-utils": "^0.14.0",
+    "react": "^0.14.2",
+    "react-addons-test-utils": "^0.14.2",
+    "react-dom": "^0.14.2",
     "reactify": "0.17.1"
   },
   "engines": {


### PR DESCRIPTION
This should resolve potential issues around multiple copies of `react` existing in a project on systems not on `npm@3.x.x`. This also slightly future-proofs `react-dom` for when they move the render functions out of the main package.

@kasperp

Closes #67 