### PR TITLE
Attribute Case Mismatch

### DIFF
--- a/ngReact.js
+++ b/ngReact.js
@@ -215,7 +215,11 @@
           var renderMyComponent = function() {
             var props = {};
             propNames.forEach(function(propName) {
-              props[propName] = scope.$eval(attrs[propName]);
+              // All key values in the 'attrs' object passed here by Angular are *lower case*
+              // So we need to compute the attribute name that Angular would use and look
+              // the attribute up by that name.
+              var attrName = propName.toLowerCase();
+              props[propName] = scope.$eval(attrs[attrName]);
             });
             renderComponent(reactComponent, applyFunctions(props, scope), $timeout, elem);
           };


### PR DESCRIPTION
I'm surprised this hasn't been realized before, but the `attrs` object passed to `link` by Angular contains only lower case keys.  In other words, Angular maps them all to lower case when processing them.  **However**, React is case sensitive.  So if the React component has a property name that includes upper case (like nearly every event handler), then you can't provide a value to it because you'll never find the name of that property in `attrs`.

This addresses that quite simply by determining both the React name, `propName`, and the corresponding Angular attribute name `attrName` and using the appropriate key in `propNames` and `attrs` respectively.