### PR TITLE
Added react-dom.js to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then, just make sure Angular, React, and ngReact are on the page,
 ```html
 <script src="bower_components/angular/angular.js"></script>
 <script src="bower_components/react/react.js"></script>
+<script src="bower_components/react/react-dom.js"></script>
 <script src="bower_components/ngReact/ngReact.min.js"></script>
 ```
 


### PR DESCRIPTION
Since the release of react 0.14, we need to include the react-dom script as well. 