### PR TITLE
pass injectables and other variables straight to the reactDirective

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ app.directive('hello', helloDirective);
 
 In an existing Angular application, you'll often have existing services or filters that you wish to access from your React component. These can be retrieved using Angular's dependency injection. The React component will still be render-able as aforementioned, using the react-component directive.
 
+It's also possible to pass Angular injectables and other variables as fourth parameter straight to the reactDirective, which will then attach them to the props
+
+```javascript
+app.directive('helloComponent', function(reactDirective, $ngRedux) {
+  return reactDirective(HelloComponent, undefined, {}, {store: $ngRedux});
+});
+```
+
 Be aware that you can not inject Angular directives into JSX.
 
 ```javascript

--- a/ngReact.js
+++ b/ngReact.js
@@ -207,7 +207,7 @@
   //     <hello name="name"/>
   //
   var reactDirective = function($injector) {
-    return function(reactComponentName, propNames, conf) {
+    return function(reactComponentName, propNames, conf, injectableProps) {
       var directive = {
         restrict: 'E',
         replace: true,
@@ -223,7 +223,9 @@
             propNames.forEach(function(propName) {
               props[propName] = scope.$eval(attrs[propName]);
             });
-            renderComponent(reactComponent, applyFunctions(props, scope), scope, elem);
+            props = applyFunctions(props, scope);
+            props = angular.extend({}, props, injectableProps);
+            renderComponent(reactComponent, props, scope, elem);
           };
 
           // watch each property name and trigger an update whenever something changes,

--- a/tests/react-directive-spec.js
+++ b/tests/react-directive-spec.js
@@ -136,6 +136,22 @@ describe('react-directive', () => {
       expect(elm.text().trim()).toEqual('Hello');
     });
 
+    it('should be possible to provide properties from directive to the reactDirective', inject(($rootScope) => {
+      compileProvider.directive('helloComponent', (reactDirective) => {
+        return reactDirective(Hello, undefined, undefined, {fname: 'Clark', lname: 'Kent'});
+      });
+      var elm = compileElement('<hello-component />', $rootScope.$new());
+      expect(elm.text().trim()).toEqual('Hello Clark Kent');
+    }));
+
+    it('properties passed to reactDirective should override colliding properties passed as param', inject(($rootScope) => {
+      compileProvider.directive('helloComponent', (reactDirective) => {
+        return reactDirective(Hello, undefined, undefined, {fname: 'Clark', lname: 'Kent'});
+      });
+      var elm = compileElement('<hello-component fname="\'toBeOverridden\'"/>', $rootScope.$new());
+      expect(elm.text().trim()).toEqual('Hello Clark Kent');
+    }));
+
     it('should bind to properties on scope', inject(($rootScope) => {
       var scope = $rootScope.$new();
       scope.firstName = 'Clark';
@@ -491,7 +507,7 @@ describe('react-directive', () => {
       scope.callback = function(unmountFn) {
         unmountFn();
       };
-      
+
       spyOn(scope, 'callback').and.callThrough();
 
       var elm = compileElement(


### PR DESCRIPTION
This makes it easier to use angular injectables in react components. This makes it also possible to pass any other variables from directive to the react component if needed.

The motivation for this is that i have to pass redux store to the react component, which happens to be $ngRedux in this cae. I wouldn't like to inject it somewhere else and pass it as a property if it's possible to inject in directive it self. 