### PR TITLE
Enable watchDepth option for individual props

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ app.directive('hello', function(reactDirective) {
 });
 ```
 
+You may also customize the watch depth per prop/attribute by wrapping the name and an options object in an array inside the props array:
+
+```javascript
+app.directive('hello', function(reactDirective) {
+  return reactDirective(HelloComponent, [
+    'person', // takes on the watch-depth of the entire directive
+    ['place', {watchDepth: 'reference'}],
+    ['things', {watchDepth: 'collection'}],
+    ['ideas', {watchDepth: 'value'}]
+  ]);
+});
+```
+
 If you want to change the configuration of the directive created the `reactDirective` service, e.g. change `restrict: 'E'` to `restrict: 'C'`, you can do so by passing in an object literal with the desired configuration.
 
 ```javascript

--- a/tests/react-directive-spec.js
+++ b/tests/react-directive-spec.js
@@ -318,6 +318,154 @@ describe('react-directive', () => {
       );
       expect(elm.text().trim()).toEqual('Hello  Bruce Wayne');
     }));
+
+    describe('propNames options', () => {
+      it('should accept propNames as array of arrays', inject(($rootScope) => {
+        compileProvider.directive('customHelloComponent', (reactDirective) => {
+          return reactDirective(Hello, [
+            ['fname'],
+            ['lname', {}]
+          ]);
+        });
+
+        var scope = $rootScope.$new();
+        scope.person = { firstName: 'Clark', lastName: 'Kent' };
+
+        var elm = compileElement(
+          '<custom-hello-component fname="person.firstName" lname="person.lastName"/>',
+          scope
+        );
+
+        expect(elm.text().trim()).toEqual('Hello Clark Kent');
+
+        scope.person.firstName = 'Bruce';
+        scope.person.lastName = 'Banner';
+        scope.$apply();
+
+        expect(elm.text().trim()).toEqual('Hello Bruce Banner');
+      }));
+
+      describe('watchDepth', () => {
+        it('should support "reference" as individual watchDepth option', inject(($rootScope) => {
+          compileProvider.directive('customPeople', (reactDirective) => {
+            return reactDirective(People, [
+              ['items', {watchDepth: 'reference'}]
+            ]);
+          });
+
+          var scope = $rootScope.$new();
+          scope.items = [
+            { fname: 'Clark', lname: 'Kent' },
+            { fname: 'Bruce', lname: 'Wayne' }
+          ];
+
+          var elm = compileElement(
+            '<custom-people items="items" />',
+            scope
+          );
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items[1] = {fname: 'Diana', lname: 'Prince'};
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items = scope.items.slice(0);
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Diana Prince');
+        }));
+
+        it('should support "collection" as individual watchDepth option', inject(($rootScope) => {
+          compileProvider.directive('customPeople', (reactDirective) => {
+            return reactDirective(People, [
+              ['items', {watchDepth: 'collection'}]
+            ]);
+          });
+
+          var scope = $rootScope.$new();
+          scope.items = [
+            { fname: 'Clark', lname: 'Kent' },
+            { fname: 'Bruce', lname: 'Wayne' }
+          ];
+
+          var elm = compileElement(
+            '<custom-people items="items" watch-depth="reference" />',
+            scope
+          );
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items[1].lname = 'Banner';
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items[1] = {fname: 'Bruce', lname: 'Banner'};
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Banner');
+        }));
+
+        it('should support "value" as individual watchDepth option', inject(($rootScope) => {
+          compileProvider.directive('customPeople', (reactDirective) => {
+            return reactDirective(People, [
+              ['items', {watchDepth: 'value'}]
+            ]);
+          });
+
+          var scope = $rootScope.$new();
+          scope.items = [
+            { fname: 'Clark', lname: 'Kent' },
+            { fname: 'Bruce', lname: 'Wayne' }
+          ];
+
+          var elm = compileElement(
+            '<custom-people items="items" watch-depth="reference" />',
+            scope
+          );
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items[1].lname = 'Banner';
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Banner');
+        }));
+
+        it("should fall back to directive's watch depth when no individual watchDepth option is provided", inject(($rootScope) => {
+          compileProvider.directive('customPeople', (reactDirective) => {
+            return reactDirective(People, [
+              ['items', {}]
+            ]);
+          });
+
+          var scope = $rootScope.$new();
+          scope.items = [
+            { fname: 'Clark', lname: 'Kent' },
+            { fname: 'Bruce', lname: 'Wayne' }
+          ];
+
+          var elm = compileElement(
+            '<custom-people items="items" watch-depth="reference" />',
+            scope
+          );
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items[1] = {fname: 'Diana', lname: 'Prince'};
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Bruce Wayne');
+
+          scope.items = scope.items.slice(0);
+          scope.$apply();
+
+          expect(elm.text().trim()).toEqual('Hello Clark Kent, Diana Prince');
+        }));
+      });
+    });
   });
 
 


### PR DESCRIPTION
Fixes #155.

Here's an example from the docs:

```javascript
app.directive('hello', function(reactDirective) {
  return reactDirective(HelloComponent, [
    'person', // takes on the watch-depth of the entire directive
    ['place', {watchDepth: 'reference'}],
    ['things', {watchDepth: 'collection'}],
    ['ideas', {watchDepth: 'value'}]
  ]);
});
```

It's fully backwards-compatible with the current usage of props (i.e., `['fname', 'lname']`) without adding another parameter to `reactDirective`. Array/options wrapper is inspired by [Browserify transforms](https://github.com/substack/node-browserify#btransformtr-opts) and [Babel plugins](https://babeljs.io/docs/plugins/#plugin-preset-options).

----

This also provides an easy API path forward for #129. `$apply` or `wrappedInApply` or something similar could be another option that gets defined per prop, just like `watchDepth`. I imagine I'll be needing that soon, so I can open a separate PR for that functionality if desired.