### PR TITLE
Pass all props if no propTypes defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This creates a directive that can be used like this:
 </body>
 ```
 
-The `reactDirective` service will read the React component `propTypes` and watch attributes with these names. If your react component doesn't have `propTypes` defined you can pass in an array of attribute names to watch. If you don't pass any array of attribute names, fall back to use directive attributes as a last resort. By default, attributes will be watched by value however you can also choose to watch by reference or collection by supplying the watch-depth attribute. Possible values are `reference`, `collection` and `value` (default).
+The `reactDirective` service will read the React component `propTypes` and watch attributes with these names. If your react component doesn't have `propTypes` defined you can pass in an array of attribute names to watch.  By default, attributes will be watched by value however you can also choose to watch by reference or collection by supplying the watch-depth attribute.  Possible values are `reference`, `collection` and `value` (default).
 
 ```javascript
 app.directive('hello', function(reactDirective) {
@@ -300,7 +300,7 @@ Run the examples by starting a webserver in the project root folder.
 
 ## Maintainers
 
-- Kasper B?gebjerg Pedersen (@kasperp)
+- Kasper B??gebjerg Pedersen (@kasperp)
 - David Chang (@davidchang)
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This creates a directive that can be used like this:
 </body>
 ```
 
-The `reactDirective` service will read the React component `propTypes` and watch attributes with these names. If your react component doesn't have `propTypes` defined you can pass in an array of attribute names to watch.  By default, attributes will be watched by value however you can also choose to watch by reference or collection by supplying the watch-depth attribute.  Possible values are `reference`, `collection` and `value` (default).
+The `reactDirective` service will read the React component `propTypes` and watch attributes with these names. If your react component doesn't have `propTypes` defined you can pass in an array of attribute names to watch. If you don't pass any array of attribute names, fall back to use directive attributes as a last resort. By default, attributes will be watched by value however you can also choose to watch by reference or collection by supplying the watch-depth attribute.  Possible values are `reference`, `collection` and `value` (default).
 
 ```javascript
 app.directive('hello', function(reactDirective) {

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Run the examples by starting a webserver in the project root folder.
 
 ## Maintainers
 
-- Kasper B??gebjerg Pedersen (@kasperp)
+- Kasper B?gebjerg Pedersen (@kasperp)
 - David Chang (@davidchang)
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This creates a directive that can be used like this:
 </body>
 ```
 
-The `reactDirective` service will read the React component `propTypes` and watch attributes with these names. If your react component doesn't have `propTypes` defined you can pass in an array of attribute names to watch.  By default, attributes will be watched by value however you can also choose to watch by reference or collection by supplying the watch-depth attribute.  Possible values are `reference`, `collection` and `value` (default).
+The `reactDirective` service will read the React component `propTypes` and watch attributes with these names. If your react component doesn't have `propTypes` defined you can pass in an array of attribute names to watch. If you don't pass any array of attribute names, fall back to use directive attributes as a last resort. By default, attributes will be watched by value however you can also choose to watch by reference or collection by supplying the watch-depth attribute. Possible values are `reference`, `collection` and `value` (default).
 
 ```javascript
 app.directive('hello', function(reactDirective) {
@@ -300,7 +300,7 @@ Run the examples by starting a webserver in the project root folder.
 
 ## Maintainers
 
-- Kasper Bøgebjerg Pedersen (@kasperp)
+- Kasper B??gebjerg Pedersen (@kasperp)
 - David Chang (@davidchang)
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Run the examples by starting a webserver in the project root folder.
 
 ## Maintainers
 
-- Kasper B??gebjerg Pedersen (@kasperp)
+- Kasper Bøgebjerg Pedersen (@kasperp)
 - David Chang (@davidchang)
 
 ## Contributors

--- a/ngReact.js
+++ b/ngReact.js
@@ -264,11 +264,11 @@
           // if props is not defined, fall back to use the React component's propTypes if present
           props = props || Object.keys(reactComponent.propTypes || {});
           if (!props.length) {
-            var noNgAttrNames = [];
+            var ngAttrNames = [];
             angular.forEach(attrs.$attr, function (value, key) {
-              noNgAttrNames.push(key);
+              ngAttrNames.push(key);
             });
-            props = noNgAttrNames;
+            props = ngAttrNames;
           }
 
           // for each of the properties, get their scope value and set it to scope.props

--- a/ngReact.js
+++ b/ngReact.js
@@ -263,6 +263,13 @@
 
           // if props is not defined, fall back to use the React component's propTypes if present
           props = props || Object.keys(reactComponent.propTypes || {});
+          if (!props.length) {
+            var noNgAttrNames = [];
+            angular.forEach(attrs.$attr, function (value, key) {
+              noNgAttrNames.push(key);
+            });
+            props = noNgAttrNames;
+          }
 
           // for each of the properties, get their scope value and set it to scope.props
           var renderMyComponent = function() {

--- a/tests/react-directive-spec.js
+++ b/tests/react-directive-spec.js
@@ -74,6 +74,20 @@ var Apply = React.createClass({
   }
 });
 
+var HelloNoPropTypes = React.createClass({
+  handleClick() {
+    var value = this.props.changeName();
+    if (value){
+      window.GlobalChangeNameValue = value;
+    }
+  },
+
+  render() {
+    var {fname, lname, undeclared} = this.props;
+
+    return <div onClick={this.handleClick}>Hello {fname} {lname}{undeclared}</div>;
+  }
+});
 
 describe('react-directive', () => {
 
@@ -351,6 +365,21 @@ describe('react-directive', () => {
         scope
       );
       expect(elm.text().trim()).toEqual('Hello  Bruce Wayne');
+    }));
+
+    it('should pass all attributes as props when no PropTypes is provided', inject(($rootScope) => {
+      provide.value('HelloNoPropTypes', HelloNoPropTypes);
+      compileProvider.directive('helloNoPropTypes', reactDirective => reactDirective('HelloNoPropTypes'));
+
+      var scope = $rootScope.$new();
+      scope.firstName = 'Clark';
+      scope.lastName = 'Kent';
+
+      var elm = compileElement(
+        '<hello-no-prop-types fname="firstName" lname="lastName"/>',
+        scope
+      );
+      expect(elm.text().trim()).toEqual('Hello Clark Kent');
     }));
 
     describe('propNames options', () => {


### PR DESCRIPTION
Be able to use directive attributes as fallback if no propTypes have been defined in React component.

Will close #193 