### PR TITLE
Fixes #200 - Lock react version in bower.json to be 15

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ngReact",
   "author": "https://github.com/davidchang/ngReact/graphs/contributors",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "main": "ngReact.js",
   "description": "Use React Components in Angular",
   "homepage": "http://davidchang.github.io/ngReact/",
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "angular": "<2.0.0",
-    "react": ">=0.15.0"
+    "react": "^15.0.0"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
This fix if for [#200](https://github.com/ngReact/ngReact/issues/200): Set react dependency in bower.json to be up to minor changes of version 15, same as package.json settings.

This prevent forced switching to react 16 for new installation via bower.

